### PR TITLE
WebApp Manifest served in /.

### DIFF
--- a/emotly/__init__.py
+++ b/emotly/__init__.py
@@ -23,6 +23,17 @@ db = MongoEngine(app)
 def index():
     return render_template("page-home.html")
 
+
+# FIXME: Serving the WebApp Manifest in the root seems to
+# be mandatory (or a bug in the implementation?), hence
+# we mock the URL here (/manifest.json instead of
+# /static/app/manifest.json).
+# The base.html template also links /manifest.json.
+@app.route("/manifest.json")
+def serve_manifest():
+    return app.send_static_file('app/manifest.json')
+
+
 # Gunicorn support.
 app.wsgi_app = ProxyFix(app.wsgi_app)
 

--- a/emotly/static/app/manifest.json
+++ b/emotly/static/app/manifest.json
@@ -3,13 +3,15 @@
   "icons": [
     {
       "src": "/static/app/icon/temp400.png",
-      "sizes": "96x96 48x48",
+      "sizes": "256x256 128x128 96x96 48x48",
       "type": "image/png"
     }
   ],
+  "start_url": "/",
   "display": "fullscreen",
   "orientation": "portrait",
   "background_color": "red",
   "lang": "en-US",
+  "scope": "/",
   "theme_color": "red"
 }

--- a/emotly/templates/base.html
+++ b/emotly/templates/base.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Emotly">
     <meta name="author" content="Emotly Dev Team">
     <link rel="icon" href="{{url_for('static', filename='favicon.ico')}}">
-    <link rel="manifest" href="{{url_for('static', filename='app/manifest.json')}}">
+    <link rel="manifest" href="manifest.json" />
 
     <title>Emotly - {% block title %}{% endblock %}</title>
     <link href="{{url_for('static', filename='pub/css/bootstrap.min.css')}}" rel="stylesheet">


### PR DESCRIPTION
The WebApp Manifest was ignored since it landed in production; it turned
out that it had to be served from the root for the UA to consider it.

We're fixing this here by mocking the /manifest.json URL by serving
whatever is in static/app/manifest.json.

Probably this is a bug of the implementer as nothing like this has been
found in the spec [1]. We'll have to revisit this issue in the future,
therefore a relevant FIXME has been added.

[1] https://w3c.github.io/manifest/