### PR TITLE
[Bug Fix] Datetime.now() causes timestamps to be always the same.

### DIFF
--- a/emotly/constants.py
+++ b/emotly/constants.py
@@ -4,7 +4,7 @@
 APP_LINK = 'https://emotly.herokuapp.com/static/app/pwa'
 
 # Generic Constants
-DATE_FORMAT = '%Y:%m:%dT%H:%M:%SZ'
+DATE_FORMAT = '%Y:%m:%dT%H:%M:%S'
 MINUTES_SINCE_LAST_EMAIL = 15
 
 # Rest API prefix

--- a/emotly/models.py
+++ b/emotly/models.py
@@ -11,7 +11,7 @@ from emotly import constants as CONSTANTS
 
 class Token(db.EmbeddedDocument):
     token = db.StringField(unique=True, sparse=True)
-    created_at = db.DateTimeField(default=datetime.datetime.now())
+    created_at = db.DateTimeField(default=datetime.datetime.now)
 
 
 class User(db.Document):
@@ -22,7 +22,7 @@ class User(db.Document):
     password = db.StringField(min_length=8, required=True)
     salt = db.StringField(required=True)
     confirmed_email = db.BooleanField(default=False)
-    created_at = db.DateTimeField(default=datetime.datetime.now())
+    created_at = db.DateTimeField(default=datetime.datetime.now)
     update_at = db.DateTimeField()
     last_login = db.DateTimeField()
     confirmation_token = db.EmbeddedDocumentField(Token)
@@ -44,7 +44,7 @@ MOOD = {1: "sad", 2: "happy", 3: "proud", 4: "tired", 5: "hopeful",
 class Emotly(db.Document):
     mood = db.IntField(required=True, choices=list(MOOD))
     user = db.ReferenceField(User, required=True)
-    created_at = db.DateTimeField(default=datetime.datetime.now())
+    created_at = db.DateTimeField(default=datetime.datetime.now)
 
     # TODO Change in something better.
     # Serialize object formatting date and mood and user if present.

--- a/emotly/tests/emotly_model_tests.py
+++ b/emotly/tests/emotly_model_tests.py
@@ -3,6 +3,7 @@ Emotly Model Test Case
 """
 import unittest
 import datetime
+import time
 from mongoengine import ValidationError
 from emotly import app
 from emotly.models import User, Emotly, MOOD
@@ -27,6 +28,31 @@ class EmotlyModelTestCase(unittest.TestCase):
         emotly = Emotly(mood=1)
         emotly.user = u
         self.assertTrue(emotly.save())
+
+    def test_create_3_emotly(self):
+        u = User(nickname='testemotly',
+                 email='test_emotly@example.com',
+                 password="FakeUserPassword123",
+                 confirmed_email=True,
+                 last_login=datetime.datetime.now,
+                 salt="salt")
+        u.save()
+
+        emotly = Emotly(mood=1)
+        emotly.user = u
+        emotly.save()
+        time.sleep(1)  # sleep time in seconds
+
+        emotly1 = Emotly(mood=2)
+        emotly1.user = u
+        emotly1.save()
+        time.sleep(1)  # sleep time in seconds
+
+        emotly2 = Emotly(mood=3)
+        emotly2.user = u
+        emotly2.save()
+        self.assertNotEqual(emotly.created_at, emotly1.created_at)
+        self.assertNotEqual(emotly1.created_at, emotly2.created_at)
 
     def test_cannot_create_emotly_whitout_user(self):
         emotly = Emotly(mood=2)

--- a/emotly/tests/token_model_tests.py
+++ b/emotly/tests/token_model_tests.py
@@ -3,6 +3,7 @@ Token Model Test Case
 """
 import unittest
 import datetime
+import time
 from mongoengine import NotUniqueError
 from emotly import app
 from emotly.models import User, Token
@@ -29,6 +30,16 @@ class TokenModelTestCase(unittest.TestCase):
         token = Token(token=token_string)
         u.confirmation_token = token
         self.assertTrue(u.save())
+
+    def test_create_3_token(self):
+        token_string = generate_confirmation_token('test@example.com')
+        token = Token(token=token_string)
+        time.sleep(1)  # sleep time in seconds
+        token1 = Token(token=token_string)
+        time.sleep(1)  # sleep time in seconds
+        token2 = Token(token=token_string)
+        self.assertNotEqual(token.created_at, token1.created_at)
+        self.assertNotEqual(token1.created_at, token2.created_at)
 
     def test_cannot_create_token_not_unique(self):
         u = User(nickname='testZ123456',

--- a/emotly/tests/user_login_tests.py
+++ b/emotly/tests/user_login_tests.py
@@ -34,6 +34,29 @@ class LoginTestCases(unittest.TestCase):
                            base_url='https://localhost')
         self.assertEqual(rv.status_code, 200)
 
+    def test_last_login_date_updated(self):
+        salt = get_salt()
+        u = User(nickname='test12345678910',
+                 email='email@emailtest.com',
+                 password=hash_password("password".encode('utf-8'), salt),
+                 confirmed_email=True,
+                 salt="salt")
+        u.save()
+
+        user_data = {'user_id': 'email@emailtest.com',
+                     'password': 'password'}
+        rv = self.app.post(CONSTANTS.REST_API_PREFIX + '/login',
+                           data=json.dumps(user_data),
+                           base_url='https://localhost')
+        user = User.objects.get(email=u.email)
+
+        rv = self.app.post(CONSTANTS.REST_API_PREFIX + '/login',
+                           data=json.dumps(user_data),
+                           base_url='https://localhost')
+        user2 = User.objects.get(email=u.email)
+
+        self.assertNotEqual(user.last_login, user2.last_login)
+
     def test_login_nickname_success(self):
         salt = get_salt()
         u = User(nickname='testnickname',

--- a/emotly/tests/user_model_tests.py
+++ b/emotly/tests/user_model_tests.py
@@ -2,6 +2,8 @@
 User Model Test Case
 """
 import unittest
+import datetime
+import time
 from mongoengine import ValidationError, NotUniqueError
 from emotly import app
 from emotly import constants as CONSTANTS
@@ -21,6 +23,33 @@ class UserModelTestCase(unittest.TestCase):
                  email='test_create_user@example.com',
                  password="FakeUserPassword123", salt="salt")
         self.assertTrue(u.save())
+
+    def test_create_3_user(self):
+        u = User(nickname='testemotly',
+                 email='test_emotly@example.com',
+                 password="FakeUserPassword123",
+                 confirmed_email=True,
+                 last_login=datetime.datetime.now(),
+                 salt="salt")
+        u.save()
+        time.sleep(1)  # sleep time in seconds
+        u1 = User(nickname='testemotly1',
+                  email='test_emotly1@example.com',
+                  password="FakeUserPassword123",
+                  confirmed_email=True,
+                  last_login=datetime.datetime.now(),
+                  salt="salt")
+        u1.save()
+        time.sleep(1)  # sleep time in seconds
+        u2 = User(nickname='testemotly2',
+                  email='test_emotly2@example.com',
+                  password="FakeUserPassword123",
+                  confirmed_email=True,
+                  last_login=datetime.datetime.now(),
+                  salt="salt")
+        u2.save()
+        self.assertNotEqual(u.created_at, u1.created_at)
+        self.assertNotEqual(u1.created_at, u2.created_at)
 
     def test_cannot_create_user_nickname_too_long(self):
         u = User(nickname='VeryLongNicknameThatIsTooLong',


### PR DESCRIPTION
Changed "now()" to "now" for all created_at default date to prevent
saving always the same timestamps.